### PR TITLE
Stop deleting fragments after compiling.

### DIFF
--- a/.changes/0.1.1/1580544677945-eLMgcyuX.yaml
+++ b/.changes/0.1.1/1580544677945-eLMgcyuX.yaml
@@ -1,0 +1,11 @@
+type: feature
+section: ''
+issues:
+  '3': https://github.com/jonathanj/cacofonix/issues/3
+feature_flags: []
+description: |-
+  Interactive mode is now significantly enhanced:
+    - Colored prompts;
+    - Autocompleting prompts for change types and sections;
+    - Syntax-highlighted, multiline (with readline-like support), description prompt;
+    - Preview of the YAML to be generated.

--- a/.changes/next/1580750569567-OS6YrBkg.yaml
+++ b/.changes/next/1580750569567-OS6YrBkg.yaml
@@ -4,4 +4,5 @@ issues:
   '5': https://github.com/jonathanj/cacofonix/issues/5
 feature_flags: []
 description: |-
-  Fragments are now archived instead of deleted. The version number is used as the directory name with `next` being used for the as-yet-unreleased version.
+  Fragments are now archived instead of deleted.
+  - The version number is used as the directory name with `next` being used for the as-yet-unreleased version.

--- a/.changes/next/1580750569567-OS6YrBkg.yaml
+++ b/.changes/next/1580750569567-OS6YrBkg.yaml
@@ -1,0 +1,7 @@
+type: feature
+section: ''
+issues:
+  '5': https://github.com/jonathanj/cacofonix/issues/5
+feature_flags: []
+description: |-
+  Fragments are now archived instead of deleted. The version number is used as the directory name with `next` being used for the as-yet-unreleased version.

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,7 @@ setup(
         'aniso8601 >= 8.0.0',
         'prompt_toolkit >= 3.0.3',
         'Pygments >= 2.5.2',
+        'semver >= 2.9.0',
+        'fs >= 2.4.11',
     ],
 )

--- a/src/cacofonix/_app.py
+++ b/src/cacofonix/_app.py
@@ -98,6 +98,8 @@ class Application(object):
                 log.debug(metadata)
                 archive_fs.settext(
                     self.METADATA_FILENAME, _yaml.dump(metadata))
+                metadata_path = archive_fs.getsyspath(self.METADATA_FILENAME)
+                self.effects.git_stage(metadata_path)
 
         return n, problems
 

--- a/src/cacofonix/_app.py
+++ b/src/cacofonix/_app.py
@@ -1,63 +1,122 @@
-import os
 import json
-from typing import Iterable, List, Optional, TextIO, Tuple
+import secrets
+import time
+from datetime import date
+from fs.base import FS
+from fs.path import join, dirname, basename, splitext
+from semver import VersionInfo, parse_version_info
+from typing import (
+    Iterable,
+    List,
+    Optional,
+    TextIO,
+    Tuple,
+    Union)
 
-from . import _yaml
+from . import _yaml, _log as log
 from ._config import Config
 from .errors import InvalidChangeMetadata, FragmentCompilationError
-from ._util import ensure_dir_exists, git_stage
 from ._towncrier import (
     render_fragment,
     render_changelog,
     merge_with_existing_changelog)
-from ._types import Fragment
+from ._types import Fragment, FoundFragment
+from ._effects import SideEffects
 
 
 class Application(object):
-    def __init__(self, config: Config):
+    METADATA_FILENAME: str = 'metadata.yaml'
+
+    def __init__(self, config: Config, effects: SideEffects):
         self.config = config
+        self.effects = effects
+        fragments_path = effects.fragments_fs.getsyspath('.')
+        log.debug(f'Fragments root: {fragments_path}')
 
     def load_fragment(self, fd: TextIO) -> Fragment:
+        """
+        Parse and validate a fragment from a stream.
+        """
         return self.validate_fragment(_yaml.load(fd))
 
-    def find_fragments(self) -> Iterable[Tuple[str, List[str]]]:
+    def find_fragments(
+            self,
+            version: Union[str, VersionInfo]
+    ) -> Iterable[FoundFragment]:
         """
+        Find all fragments for a particular verison.
         """
-        fragments_path = self.config.change_fragments_path
-        for dirpath, dirnames, filenames in os.walk(fragments_path):
-            yield (
-                None if dirpath == fragments_path else dirpath,
-                [os.path.join(dirpath, filename)
-                 for filename in filenames
-                 if os.path.splitext(filename)[-1] == '.yaml'])
+        log.debug(f'Finding fragments for version {version}')
+        version_fs = self.effects.fragments_fs.opendir(str(version))
+        matches = version_fs.filterdir(
+            '.',
+            files=['*.yaml'],
+            exclude_files=[self.METADATA_FILENAME])
+        for file_info in matches:
+            file_path = file_info.name
+            log.debug(f'Found {file_path}')
+            yield version_fs, file_path
 
-    def find_all_fragments(self) -> Iterable[str]:
+    def find_new_fragments(self) -> Iterable[FoundFragment]:
         """
-        Find all fragment files in the config value `change_fragments_path`.
+        Find fragment files for the next version.
         """
-        for dirpath, filepaths in self.find_fragments():
-            for path in filepaths:
-                yield path
+        return self.find_fragments('next')
 
-    def remove_fragments(self) -> Tuple[int, List[str]]:
+    def archive_fragments(
+            self,
+            found_fragments: Iterable[FoundFragment],
+            version: VersionInfo,
+            version_date: date,
+            version_author: str,
+    ) -> Tuple[int, List[str]]:
         """
-        Remove all fragment files in the config value `change_fragments_path`.
+        Archive new fragment, into the path for ``version``.
         """
-        not_removed = []
+        problems = []
         n = 0
-        for n, (dirname, filepaths) in enumerate(self.find_fragments(), 1):
-            for path in filepaths:
+        with self.effects.archive_fs(str(version)) as archive_fs:
+            log.info(f'Archiving for {version}')
+            for n, (version_fs, filename) in enumerate(found_fragments, 1):
                 try:
-                    os.remove(path)
-                    git_stage(path)
+                    path = version_fs.getsyspath(filename)
+                    archive_path = archive_fs.getsyspath(filename)
+                    log.info(f'Archive {path} -> {archive_path}')
+                    self.effects.git_mv(path, archive_path)
+                    self.effects.git_stage(archive_path)
                 except (OSError, FileNotFoundError):
-                    not_removed.append(path)
-            if dirname is not None:
-                try:
-                    os.rmdir(dirname)
-                except (OSError, FileNotFoundError):
-                    not_removed.append(dirname)
-        return n, not_removed
+                    log.exception(
+                        f'Unable to archive fragment: {version_fs} {filename}')
+                    problems.append(path)
+
+            if not problems:
+                log.info('Writing archival metadata')
+                metadata = {
+                    'date': version_date,
+                    'version': str(version),
+                    'author': version_author}
+                log.debug(metadata)
+                archive_fs.settext(
+                    self.METADATA_FILENAME, _yaml.dump(metadata))
+
+        return n, problems
+
+    def create_new_fragment(self, yaml_text: str) -> str:
+        """
+        Generate a unique filename for a fragment, and write the content to it.
+        """
+        filename = '{}-{}.yaml'.format(
+            int(time.time() * 1000),
+            secrets.token_urlsafe(6))
+        with self.effects.archive_fs('next') as next_fs:
+            if next_fs.exists(filename):
+                raise RuntimeError(
+                    'Generated fragment name already exists!', filename)
+            path = next_fs.getsyspath(filename)
+            log.debug(f'Writing new fragment {path}')
+            next_fs.settext(filename, yaml_text)
+            self.effects.git_stage(path)
+            return filename
 
     def validate_fragment(self, fragment: Optional[Fragment]) -> Fragment:
         """
@@ -90,86 +149,109 @@ class Application(object):
         fragment = _yaml.load(fragment_text)
         self.validate_fragment(fragment)
 
-    def compile_fragment_files(self, parent_dir: str,
-                               fragment_paths: List[str]) -> int:
+    def compile_fragment_files(
+            self,
+            write_fs: FS,
+            found_fragments: Iterable[FoundFragment]) -> int:
         """
         Compile fragment files into `parent_dir`.
         """
         n = 0
-        for n, fragment_path in enumerate(fragment_paths, 1):
-            with open(fragment_path, 'rb') as fd:
-                try:
-                    fragment = self.load_fragment(fd)
-                    fragment_type = fragment.get('type')
-                    showcontent = self.config.fragment_types.get(
-                        fragment_type, {}).get('showcontent', True)
-                    section = fragment.get('section') or None
-                    filename = os.path.splitext(
-                        os.path.basename(fragment_path))[0]
-                    output_path = os.path.join(
-                        parent_dir,
-                        *filter(None, [
-                            section,
-                            '{}.{}'.format(filename, fragment_type)]))
-                    rendered_content = render_fragment(
-                        fragment,
-                        showcontent,
-                        self.config.changelog_output_type)
-                    if rendered_content.strip():
-                        with open(ensure_dir_exists(output_path), 'w') as fd:
-                            fd.write(rendered_content)
-                except Exception:
-                    raise FragmentCompilationError(fragment_path)
+        for n, (version_fs, filename) in enumerate(found_fragments, 1):
+            try:
+                fragment = self.load_fragment(version_fs.gettext(filename))
+                fragment_type = fragment.get('type')
+                showcontent = self.config.fragment_types.get(
+                    fragment_type, {}).get('showcontent', True)
+                section = fragment.get('section') or None
+                rendered_content = render_fragment(
+                    fragment,
+                    showcontent,
+                    self.config.changelog_output_type)
+                if rendered_content.strip():
+                    filename_stem = splitext(basename(filename))[0]
+                    output_path = join(*filter(None, [
+                        section,
+                        '{}.{}'.format(filename_stem, fragment_type)]))
+                    log.info(
+                        'Compiling {} -> {}'.format(
+                            version_fs.getsyspath(filename),
+                            write_fs.getsyspath(output_path)))
+                    parent_dir = dirname(output_path)
+                    if parent_dir:
+                        write_fs.makedirs(parent_dir, recreate=True)
+                    write_fs.writetext(output_path, rendered_content)
+            except Exception:
+                raise FragmentCompilationError(filename)
         return n
 
     def render_changelog(
             self,
-            parent_dir: str,
-            project_version: str,
-            project_date: str) -> str:
+            fs: FS,
+            version: VersionInfo,
+            version_date: date) -> str:
         """
         Find compiled fragments in `parent_dir` and render a changelog with
         them.
         """
+        parent_dir = fs.getsyspath('.')
         return render_changelog(
             parent_dir,
             self.config.changelog_output_type,
             self.config._towncrier_sections(parent_dir),
             self.config._towncrier_fragment_types(),
             self.config._towncrier_underlines(),
-            project_version=project_version,
-            project_date=project_date)
+            project_version=str(version),
+            project_date=version_date.isoformat())
 
     def merge_with_existing_changelog(self, changelog: str) -> None:
         """
         Merge a new changelog into an existing one.
         """
-        return merge_with_existing_changelog(
-            self.config.changelog_path,
-            self.config.changelog_marker,
-            changelog)
+        with self.effects.changelog_fs() as changelog_fs:
+            changelog_path = changelog_fs.getsyspath(
+                self.config.changelog_path)
+            merge_with_existing_changelog(
+                changelog_path,
+                self.config.changelog_marker,
+                changelog)
+            self.effects.git_stage(changelog_path)
 
-    def guess_version(self) -> Optional[str]:
+    def guess_version(self, cwd_fs) -> Optional[str]:
         """
         Attempt to guess the software version.
         """
         guesses = [package_json]
         for guess in guesses:
-            result = guess(os.getcwd())
+            result = guess(cwd_fs)
             if result is not None:
                 return result
         return None
 
+    def known_versions(self) -> List[VersionInfo]:
+        """
+        Sorted list of archived versions.
+        """
+        fragments_fs = self.effects.fragments_fs
+        return sorted(
+            (parse_version_info(info.name) for info in
+             fragments_fs.filterdir(
+                 '.',
+                 exclude_files=['*'],
+                 exclude_dirs=['next'])),
+            reverse=True)
 
-def package_json(cwd):
+
+def package_json(cwd_fs: FS):
     """
     Try guess a version from ``package.json``.
     """
-    package_path = os.path.join(cwd, 'package.json')
-    if os.path.exists(package_path):
+    log.debug('Looking for package.json')
+    if cwd_fs.exists('package.json'):
+        log.debug('Guessing version with package.json')
         try:
-            with open(package_path, 'r') as fd:
-                return ('package.json', json.load(fd).get('version'))
+            return ('package.json',
+                    json.load(cwd_fs.gettext('package.json')).get('version'))
         except json.JSONDecodeError:
             pass
     return None

--- a/src/cacofonix/_effects.py
+++ b/src/cacofonix/_effects.py
@@ -84,7 +84,7 @@ class RealSideEffects(SideEffects):
         return self.fragments_fs.makedir(path, recreate=True)
 
     def changelog_fs(self) -> FS:
-        return self.root_fs
+        return self.root_fs.opendir('.')
 
     def git_mv(self, src, dst):
         check_call(['git', 'mv', src, dst])

--- a/src/cacofonix/_effects.py
+++ b/src/cacofonix/_effects.py
@@ -1,0 +1,134 @@
+from abc import ABC, abstractmethod
+from fs import open_fs
+from fs.base import FS
+from fs.wrap import read_only
+from subprocess import check_call, check_output
+from typing import Optional
+
+from . import _log as log
+from ._config import Config
+
+
+class SideEffects(ABC):
+    """
+    Abstract side effects class.
+    """
+    root_fs: FS
+    fragments_fs: FS
+
+    def __init__(self, root_fs):
+        self.root_fs = root_fs
+
+    @abstractmethod
+    def archive_fs(self, path: str) -> FS:
+        """
+        Generate an FS for an archival version.
+        """
+
+    @abstractmethod
+    def changelog_fs(self) -> FS:
+        """
+        Generate an FS for where the changelog resides.
+        """
+        # TODO: This is not ideal, since it allows access to the rest of the
+        # directory too.
+
+    def cwd_fs(self) -> FS:
+        """
+        Read-only version of the current working directory.
+        """
+        return read_only(self.root_fs)
+
+    def git_user(self) -> Optional[str]:
+        """
+        ``git config user.name`` and ``git config user.email``.
+        """
+        username = check_output(
+            ['git', 'config', 'user.name'], text=True).strip()
+        email = check_output(
+            ['git', 'config', 'user.email'], text=True).strip()
+        if not username and not email:
+            return None
+
+        if not email:
+            return username
+        elif not username:
+            return f'<{email}>'
+        return f'{username} <{email}>'
+
+    @abstractmethod
+    def git_mv(self, src: str, dst: str) -> None:
+        """
+        ``git mv <src> <dst>``
+        """
+
+    @abstractmethod
+    def git_stage(self, src: str) -> None:
+        """
+        ``git stage <src>``
+        """
+
+
+class RealSideEffects(SideEffects):
+    """
+    Perform real side effects that change things like git repositories and
+    filesystems.
+    """
+    def __init__(self, root_fs: FS, config: Config):
+        super(RealSideEffects, self).__init__(root_fs)
+        self.fragments_fs = root_fs.makedir(
+            config.change_fragments_path,
+            recreate=True)
+
+    def archive_fs(self, path: str) -> FS:
+        return self.fragments_fs.makedir(path, recreate=True)
+
+    def changelog_fs(self) -> FS:
+        return self.root_fs
+
+    def git_mv(self, src, dst):
+        check_call(['git', 'mv', src, dst])
+
+    def git_stage(self, src):
+        check_call(['git', 'add', src])
+
+
+def _dry_run_method(name: str):
+    """
+    Create a dry run stub that logs the action it would have taken.
+    """
+    def _func(self, *a, **kw):
+        log.info(
+            'Dry run of {}: {} {}'.format(
+                name,
+                ' '.join(map(repr, a)),
+                ' '.join(f'{key}={repr(value)}' for key, value in kw.items())))
+    return _func
+
+
+class DryRunSideEffects(SideEffects):
+    """
+    Dry run side effects that change only temporary files or log actions instead
+    of performing them.
+    """
+    git_mv = _dry_run_method('git_mv')
+    git_stage = _dry_run_method('git_stage')
+
+    def __init__(self, root_fs: FS, config: Config):
+        super(DryRunSideEffects, self).__init__(root_fs)
+        self.fragments_fs = read_only(
+            root_fs.opendir(config.change_fragments_path))
+
+    def archive_fs(self, path: str) -> FS:
+        return open_fs('temp://')
+
+    def changelog_fs(self) -> FS:
+        return open_fs('temp://')
+
+
+def make_effects(root_fs: FS, config: Config, dry_run: bool) -> SideEffects:
+    """
+    Make the most appropriate ``SideEffects`` instance.
+    """
+    Effects = DryRunSideEffects if dry_run else RealSideEffects
+    return Effects(root_fs, config)

--- a/src/cacofonix/_log.py
+++ b/src/cacofonix/_log.py
@@ -1,0 +1,25 @@
+import logging
+
+
+_logger = None
+
+
+def setup_logging(level):
+    logging.basicConfig(level=level)
+    global _logger
+    _logger = logging.getLogger('cacofonix')
+
+
+def _log_method(name):
+    def __log_method(*a, **kw):
+        global _logger
+        assert _logger is not None
+        return getattr(_logger, name)(*a, **kw)
+    return __log_method
+
+
+debug = _log_method('debug')
+warning = _log_method('warning')
+info = _log_method('info')
+error = _log_method('error')
+exception = _log_method('exception')

--- a/src/cacofonix/_types.py
+++ b/src/cacofonix/_types.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
+from fs.base import FS
 
 
 # TODO: Python 3.7 doesn't have `TypedDict`.
@@ -6,3 +7,4 @@ Fragment = Dict[str, Any]
 # TODO: Python 3.7 doesn't have `Literal`.
 # OutputType = Literal['markdown', 'rest']
 OutputType = str
+FoundFragment = Tuple[FS, str]

--- a/src/cacofonix/_util.py
+++ b/src/cacofonix/_util.py
@@ -1,8 +1,4 @@
-import os
-import shutil
-import tempfile
 from codecs import encode, decode
-from subprocess import check_call
 
 
 def pluralize(n: int, singular: str, plural: str) -> str:
@@ -17,34 +13,3 @@ def string_escape(s: str) -> str:
     Like `.decode('string-escape')` in Python 2 but harder because Python 3.
     """
     return decode(encode(s, 'latin-1', 'backslashreplace'), 'unicode-escape')
-
-
-def git_stage(path: str) -> None:
-    """
-    Stage `path` in git.
-    """
-    check_call(['git', 'add', path])
-
-
-class TemporaryDirectory(object):
-    """
-    Context manager that will create and destroy a temporary directory.
-    """
-    def __enter__(self):
-        self.path = tempfile.mkdtemp(prefix='bard')
-        return self.path
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        shutil.rmtree(self.path)
-        self.path = None
-
-
-def ensure_dir_exists(path: str) -> str:
-    """
-    Ensure that the parent of `path` exists, creating it and all subdirectories
-    if necessary.
-    """
-    dirname = os.path.dirname(path)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
-    return path


### PR DESCRIPTION
This required a new version directory structure, where unversioned
fragments are stored in `next` and fragments are moved from `next` when
a changelog is compiled for a particular version.

Additionally side effects have been refactored and isolated. This makes
it possible to implement dry run with a reasonable degree of confidence
that it won't make any changes.

Fixes #5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/cacofonix/6)
<!-- Reviewable:end -->
