### PR TITLE
Match new towncrier `render_fragments` API.

### DIFF
--- a/src/cacofonix/_towncrier.py
+++ b/src/cacofonix/_towncrier.py
@@ -109,10 +109,12 @@ def render_changelog(
         'templates/towncrier_rest.tmpl')
     template = pkgutil.get_data(__name__, template_name).decode('utf-8')
     issue_format = ''
+    top_line = ''
     wrap = False
     return render_fragments(
         template,
         issue_format,
+        top_line,
         fragments,
         fragment_types,
         underlines,


### PR DESCRIPTION
To fix this:

```
  File "/Users/vagrant/Library/Python/3.9/lib/python/site-packages/cacofonix/_app.py", line 207, in render_changelog
    return render_changelog(
  File "/Users/vagrant/Library/Python/3.9/lib/python/site-packages/cacofonix/_towncrier.py", line 113, in render_changelog
    return render_fragments(
TypeError: render_fragments() missing 1 required positional argument: 'versiondata'```